### PR TITLE
Use externs in common.h

### DIFF
--- a/ext/rpi_gpio/common.c
+++ b/ext/rpi_gpio/common.c
@@ -34,6 +34,9 @@ const int pin_to_gpio_rev2[41] = {-1, -1, -1, 2, -1, 3, -1, 4, 14, -1, 15, 17, 1
 const int pin_to_gpio_rev3[41] = {-1, -1, -1, 2, -1, 3, -1, 4, 14, -1, 15, 17, 18, 27, -1, 22, 23, -1, 24, 10, -1, 9, 25, 11, 8, -1, 7, -1, -1, 5, -1, 6, 12, 13, -1, 19, 16, 26, 20, -1, 21 };
 int setup_error = 0;
 int module_setup = 0;
+const int (*pin_to_gpio)[41];
+int gpio_direction[54];
+rpi_info rpiinfo;
 
 int check_gpio_priv(void)
 {

--- a/ext/rpi_gpio/common.h
+++ b/ext/rpi_gpio/common.h
@@ -34,14 +34,14 @@ SOFTWARE.
 #define I2C          42
 #define PWM          43
 
-int gpio_mode;
-const int pin_to_gpio_rev1[41];
-const int pin_to_gpio_rev2[41];
-const int pin_to_gpio_rev3[41];
-const int (*pin_to_gpio)[41];
-int gpio_direction[54];
-rpi_info rpiinfo;
-int setup_error;
-int module_setup;
+extern int gpio_mode;
+extern const int pin_to_gpio_rev1[41];
+extern const int pin_to_gpio_rev2[41];
+extern const int pin_to_gpio_rev3[41];
+extern const int (*pin_to_gpio)[41];
+extern int gpio_direction[54];
+extern rpi_info rpiinfo;
+extern int setup_error;
+extern int module_setup;
 int check_gpio_priv(void);
 int get_gpio_number(int channel, unsigned int *gpio);


### PR DESCRIPTION
This PR fixes an issue when compiling with gcc 10.  `extern` statements are required when declaring variables in header files, so this adds these.

Without this PR, this is what is seen when compiling with gcc 10:

```
linking shared-object rpi_gpio/rpi_gpio.so
/usr/bin/ld: rb_gpio.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:37: multiple definition of `gpio_mode'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:37: first defined here
/usr/bin/ld: rb_gpio.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:43: multiple definition of `rpiinfo'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:43: first defined here
/usr/bin/ld: rb_gpio.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:41: multiple definition of `pin_to_gpio'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:41: first defined here
/usr/bin/ld: rb_gpio.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:45: multiple definition of `module_setup'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:45: first defined here
/usr/bin/ld: rb_gpio.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:44: multiple definition of `setup_error'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:44: first defined here
/usr/bin/ld: rb_gpio.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:42: multiple definition of `gpio_direction'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:42: first defined here
/usr/bin/ld: rb_gpio.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:40: multiple definition of `pin_to_gpio_rev3'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:40: first defined here
/usr/bin/ld: rb_gpio.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:39: multiple definition of `pin_to_gpio_rev2'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:39: first defined here
/usr/bin/ld: rb_gpio.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:38: multiple definition of `pin_to_gpio_rev1'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:38: first defined here
/usr/bin/ld: rb_pwm.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:42: multiple definition of `gpio_direction'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:42: first defined here
/usr/bin/ld: rb_pwm.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:45: multiple definition of `module_setup'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:45: first defined here
/usr/bin/ld: rb_pwm.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:44: multiple definition of `setup_error'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:44: first defined here
/usr/bin/ld: rb_pwm.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:43: multiple definition of `rpiinfo'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:43: first defined here
/usr/bin/ld: rb_pwm.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:41: multiple definition of `pin_to_gpio'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:41: first defined here
/usr/bin/ld: rb_pwm.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:40: multiple definition of `pin_to_gpio_rev3'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:40: first defined here
/usr/bin/ld: rb_pwm.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:39: multiple definition of `pin_to_gpio_rev2'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:39: first defined here
/usr/bin/ld: rb_pwm.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:38: multiple definition of `pin_to_gpio_rev1'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:38: first defined here
/usr/bin/ld: rb_pwm.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:37: multiple definition of `gpio_mode'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:37: first defined here
/usr/bin/ld: rpi_gpio.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:45: multiple definition of `module_setup'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:45: first defined here
/usr/bin/ld: rpi_gpio.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:44: multiple definition of `setup_error'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:44: first defined here
/usr/bin/ld: rpi_gpio.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:43: multiple definition of `rpiinfo'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:43: first defined here
/usr/bin/ld: rpi_gpio.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:42: multiple definition of `gpio_direction'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:42: first defined here
/usr/bin/ld: rpi_gpio.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:41: multiple definition of `pin_to_gpio'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:41: first defined here
/usr/bin/ld: rpi_gpio.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:40: multiple definition of `pin_to_gpio_rev3'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:40: first defined here
/usr/bin/ld: rpi_gpio.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:39: multiple definition of `pin_to_gpio_rev2'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:39: first defined here
/usr/bin/ld: rpi_gpio.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:38: multiple definition of `pin_to_gpio_rev1'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:38: first defined here
/usr/bin/ld: rpi_gpio.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:37: multiple definition of `gpio_mode'; common.o:/home/deploy/on-air/.misc/rpi_gpio/tmp/armv7l-linux-eabihf/rpi_gpio/3.0.2/../../../../ext/rpi_gpio/common.h:37: first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:262: rpi_gpio.so] Error 1
```